### PR TITLE
compose migration from 3.4 to 3.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.4"
+version: "3.5"
 services:
   https-portal.dnp.dappnode.eth:
     build: .
@@ -12,9 +12,17 @@ services:
       CERTAPI_URL: "ns.dappnode.io:5000"
       PUBLIC_DOMAIN: null
       FORCE: null
+    networks:
+      dncore_network:
+        aliases:
+          - https-portal.dappnode
     volumes:
       - "portal-certs:/var/lib/https-portal/"
       - "portal-data:/var/run/domains.d/"
 volumes:
   portal-certs: {}
   portal-data: {}
+networks:
+  dncore_network:
+    name: dncore_network
+    external: true


### PR DESCRIPTION
- Set `dncore_network` as external (will be asumme as created. The installer should create at installation https://github.com/dappnode/DAppNode_Installer/pull/98)
- Add alias

More info in https://github.com/dappnode/DNP_DAPPMANAGER/issues/655