### PR TITLE
fixed typo in license type GLP>GPL + move line down in file

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -4,11 +4,11 @@
   "description": "HTTPS portal for DAppNode",
   "type": "dncore",
   "author": "DAppNode Association <admin@dappnode.io> (https://github.com/dappnode)",
-  "license": "GLP-3.0",
   "contributors": ["Shardlabs <info@shardlabs.io> (https://shardlabs.io/)"],
   "architectures": ["linux/amd64", "linux/arm64"],
   "categories": ["Developer tools"],
   "keywords": ["DAppNodeCore"],
+  "license": "GPL-3.0",
   "links": {
     "homepage": "https://github.com/dappnode/DNP_HTTPS"
   },


### PR DESCRIPTION
seems that the license abbreviation has been copied into several core packages as GLP-3.0 not GPL-3.0 as is correct.  Also i moved the license line down to where it is on other core packages, just above the links section, i put it too high on my last commit which was merged.