### PR TITLE
Fix empty dappnode domain

### DIFF
--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -1,4 +1,9 @@
-import express, { ErrorRequestHandler, Request, Response } from "express";
+import express, {
+  ErrorRequestHandler,
+  Request,
+  Response,
+  Express,
+} from "express";
 import morgan from "morgan";
 import { HttpError, BadRequestError, asyncHandler } from "./utils/asyncHandler";
 import { entriesDb } from "./db";
@@ -6,82 +11,87 @@ import { reconfigureNGINX } from "./utils/nginx";
 import { sanitizeExternal, sanitizeFrom, sanitizeTo } from "./utils/sanitize";
 import { config } from "../config";
 
-const app = express();
+function getApp(dappnodeDomain: string): Express {
+  const app = express();
 
-app.use(morgan("tiny"));
+  app.use(morgan("tiny"));
 
-app.get(
-  "/add",
-  asyncHandler(async (req) => {
-    const from = await sanitizeFrom(req.query.from as string);
-    const to = sanitizeTo(req.query.to as string);
-    const external = sanitizeExternal(req.query.external as string); //true if not set, we should swap this, but it left like this for backwards compatibility
+  app.get(
+    "/add",
+    asyncHandler(async (req) => {
+      const from = await sanitizeFrom(req.query.from as string);
+      const to = sanitizeTo(req.query.to as string);
+      const external = sanitizeExternal(req.query.external as string); //true if not set, we should swap this, but it left like this for backwards compatibility
 
-    const entries = entriesDb.read();
-    if (entries.some((entry) => entry.from === from)) {
-      throw new BadRequestError("External endpoint already exists");
-    }
+      const entries = entriesDb.read();
+      if (entries.some((entry) => entry.from === from)) {
+        throw new BadRequestError("External endpoint already exists");
+      }
 
-    // NGINX will crash in loop if a domain is longer than `server_names_hash_bucket_size`
-    // Force that from has only ASCII characters to make sure the char length = bytes lenght
-    // fulldomain = from + "." + dappnodeDomain
-    const dappnodeDomain = process.env._DAPPNODE_GLOBAL_DOMAIN;
-    const maxLen = config.maximum_domain_length - dappnodeDomain.length - 1;
-    if (from.length > maxLen) {
-      throw new BadRequestError(`'from' ${from} exceeds max length of ${from}`);
-    }
+      // NGINX will crash in loop if a domain is longer than `server_names_hash_bucket_size`
+      // Force that from has only ASCII characters to make sure the char length = bytes lenght
+      // fulldomain = from + "." + dappnodeDomain
+      const maxLen = config.maximum_domain_length - dappnodeDomain.length - 1;
+      if (from.length > maxLen) {
+        throw new BadRequestError(
+          `'from' ${from} exceeds max length of ${from}`
+        );
+      }
 
-    entries.push({ from, to, external });
-    entriesDb.write(entries);
+      entries.push({ from, to, external });
+      entriesDb.write(entries);
 
-    const reconfigured = await reconfigureNGINX();
-    if (!reconfigured) {
-      entriesDb.write(entries.filter((e) => e.from !== from)); // rollback
-      await reconfigureNGINX();
-      throw new HttpError("Unable to add mapping", 500);
-    }
-  })
-);
+      const reconfigured = await reconfigureNGINX(dappnodeDomain);
+      if (!reconfigured) {
+        entriesDb.write(entries.filter((e) => e.from !== from)); // rollback
+        await reconfigureNGINX(dappnodeDomain);
+        throw new HttpError("Unable to add mapping", 500);
+      }
+    })
+  );
 
-app.get(
-  "/remove",
-  asyncHandler(async (req) => {
-    const from = await sanitizeFrom(req.query.from as string);
+  app.get(
+    "/remove",
+    asyncHandler(async (req) => {
+      const from = await sanitizeFrom(req.query.from as string);
 
-    const entries = entriesDb.read();
-    entriesDb.write(entries.filter((e) => e.from !== from));
+      const entries = entriesDb.read();
+      entriesDb.write(entries.filter((e) => e.from !== from));
 
-    await reconfigureNGINX();
-  })
-);
+      await reconfigureNGINX(dappnodeDomain);
+    })
+  );
 
-app.get(
-  "/",
-  asyncHandler(async () => entriesDb.read())
-);
+  app.get(
+    "/",
+    asyncHandler(async () => entriesDb.read())
+  );
 
-app.get(
-  "/reconfig",
-  asyncHandler(async () => await reconfigureNGINX())
-);
+  app.get(
+    "/reconfig",
+    asyncHandler(async () => await reconfigureNGINX(dappnodeDomain))
+  );
 
-app.get(
-  "/clear",
-  asyncHandler(async () => {
-    entriesDb.write([]);
-    await reconfigureNGINX();
-  })
-);
+  app.get(
+    "/clear",
+    asyncHandler(async () => {
+      entriesDb.write([]);
+      await reconfigureNGINX(dappnodeDomain);
+    })
+  );
 
-app.use((_req: Request, res: Response) => {
-  res.status(404).json({ error: "Not Found" });
-});
+  app.use((_req: Request, res: Response) => {
+    res.status(404).json({ error: "Not Found" });
+  });
 
-// Default error handler
-app.use(function (err, _req, res, next) {
-  if (res.headersSent) return next(err);
-  const code = err instanceof HttpError ? err.code : 500;
-  res.status(code).json({ error: err.message });
-} as ErrorRequestHandler);
+  // Default error handler
+  app.use(function (err, _req, res, next) {
+    if (res.headersSent) return next(err);
+    const code = err instanceof HttpError ? err.code : 500;
+    res.status(code).json({ error: err.message });
+  } as ErrorRequestHandler);
 
-export { app };
+  return app;
+}
+
+export { getApp };

--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -11,7 +11,7 @@ import { reconfigureNGINX } from "./utils/nginx";
 import { sanitizeExternal, sanitizeFrom, sanitizeTo } from "./utils/sanitize";
 import { config } from "../config";
 
-function getApp(dappnodeDomain: string): Express {
+function getHttpsApi(dappnodeDomain: string): Express {
   const app = express();
 
   app.use(morgan("tiny"));
@@ -94,4 +94,4 @@ function getApp(dappnodeDomain: string): Express {
   return app;
 }
 
-export { getApp };
+export { getHttpsApi };

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,4 @@
-import { app } from "./app";
+import { getApp } from "./app";
 import { AddressInfo } from "net";
 import { reconfigureNGINX } from "./utils/nginx";
 import { entriesDb } from "./db";
@@ -15,9 +15,10 @@ function dbMigration() {
   );
 }
 
-export default async function startAPI() {
+export default async function startAPI(dappnodeDomain: string) {
   dbMigration();
-  await reconfigureNGINX();
+  await reconfigureNGINX(dappnodeDomain);
+  const app = getApp(dappnodeDomain);
   const server = app.listen(5000, "0.0.0.0", () => {
     const { port, address } = server.address() as AddressInfo;
     console.log("Server listening on:", "http://" + address + ":" + port);

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,4 @@
-import { getApp } from "./app";
+import { getHttpsApi } from "./app";
 import { AddressInfo } from "net";
 import { reconfigureNGINX } from "./utils/nginx";
 import { entriesDb } from "./db";
@@ -18,8 +18,8 @@ function dbMigration() {
 export default async function startAPI(dappnodeDomain: string) {
   dbMigration();
   await reconfigureNGINX(dappnodeDomain);
-  const app = getApp(dappnodeDomain);
-  const server = app.listen(5000, "0.0.0.0", () => {
+  const httpsApi = getHttpsApi(dappnodeDomain);
+  const server = httpsApi.listen(5000, "0.0.0.0", () => {
     const { port, address } = server.address() as AddressInfo;
     console.log("Server listening on:", "http://" + address + ":" + port);
   });

--- a/src/api/utils/nginx.ts
+++ b/src/api/utils/nginx.ts
@@ -4,8 +4,11 @@ import { updateServerConfigs } from "../../nginx";
 
 const maxRetries = 3;
 
-export async function reconfigureNGINX(force = false): Promise<boolean> {
-  await updateServerConfigs(entriesDb.read(), force);
+export async function reconfigureNGINX(
+  dappnodeDomain: string,
+  force = false
+): Promise<boolean> {
+  await updateServerConfigs(entriesDb.read(), force, dappnodeDomain);
   for (let i = 0; i < maxRetries; i++) {
     try {
       await shell("nginx -s reload");

--- a/src/certificates/index.ts
+++ b/src/certificates/index.ts
@@ -16,7 +16,7 @@ export async function ensureValidCert(createIfNotExists = false) {
   }
 }
 
-export default async function initCertificateProvider() {
+export default async function initCertificateProvider(dappnodeDomain: string) {
   console.log("Certificates provider initializing");
   try {
     console.log("- Creating Dummy certificate");
@@ -26,7 +26,7 @@ export default async function initCertificateProvider() {
     console.log("- Generating DH parameters (this may take a while)");
     await generateDHParam();
     console.log("- Creating Certificate signing request");
-    await createCSR();
+    await createCSR(dappnodeDomain);
     console.log("Certificates provider initialized");
   } catch (e) {
     console.log(e);

--- a/src/certificates/openssl.ts
+++ b/src/certificates/openssl.ts
@@ -37,14 +37,13 @@ async function generateDomainKey() {
   await shell(`openssl genrsa ${keyLength} > ${config.keyPath}`);
 }
 
-async function createCSR() {
+async function createCSR(dappnodeDomain: string) {
   if (fs.existsSync(config.csrPath)) {
     console.log("Exists, skipping");
     return;
   }
-  const publicDomain = process.env._DAPPNODE_GLOBAL_DOMAIN;
   await shell(
-    `openssl req -new -sha256 -key ${config.keyPath} -subj '/CN=${publicDomain}' -addext 'subjectAltName = DNS:*.${publicDomain}' > ${config.csrPath}`
+    `openssl req -new -sha256 -key ${config.keyPath} -subj '/CN=${dappnodeDomain}' -addext 'subjectAltName = DNS:*.${dappnodeDomain}' > ${config.csrPath}`
   );
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,9 @@ async function main() {
     ? process.env._DAPPNODE_GLOBAL_DOMAIN
     : await retrieveDappnodeDomain();
 
+  if (process.env._DAPPNODE_GLOBAL_DOMAIN)
+    console.log("Domain retrieved from environment:", dappnodeDomain);
+
   if (!fs.existsSync(config.serverConfigDir)) {
     fs.mkdirSync(config.serverConfigDir);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,12 @@ import prepareNGINX from "./nginx";
 import shell from "./utils/shell";
 import fs from "fs";
 import { config } from "./config";
+import axios from "axios";
+
 async function main() {
-  if (!process.env._DAPPNODE_GLOBAL_DOMAIN) {
-    console.error("DAppManager did not inject enviornment. Quitting.");
-    process.exit(1);
-  }
+  const dappnodeDomain = process.env._DAPPNODE_GLOBAL_DOMAIN
+    ? process.env._DAPPNODE_GLOBAL_DOMAIN
+    : await retrieveDappnodeDomain();
 
   if (!fs.existsSync(config.serverConfigDir)) {
     fs.mkdirSync(config.serverConfigDir);
@@ -19,9 +20,29 @@ async function main() {
   }
 
   await prepareNGINX();
-  await initCertificateProvider();
+  await initCertificateProvider(dappnodeDomain);
   await shell("nginx -q");
-  startAPI();
+  startAPI(dappnodeDomain);
+}
+
+async function retrieveDappnodeDomain(): Promise<string> {
+  while (true) {
+    try {
+      const response = await axios.get(
+        "http://my.dappnode/global-envs/DOMAIN/"
+      );
+      const domain: string = response.data;
+      console.log("Domain retrieved from Dappmanager API:", domain);
+      return domain; // Return the domain once it is available
+    } catch (error) {
+      console.error(
+        "Error: Dappnode domain could not be retrieved from dappmanager API",
+        error.message
+      );
+      // Retry after 5s delay
+      await new Promise((resolve) => setTimeout(resolve, 5000));
+    }
+  }
 }
 
 main();

--- a/src/nginx/index.ts
+++ b/src/nginx/index.ts
@@ -23,7 +23,8 @@ async function deleteOldConfig(mappings: DomainMapping[]): Promise<void> {
 
 export async function updateServerConfigs(
   mappings: DomainMapping[],
-  force: boolean
+  force: boolean,
+  dappnodeDomain: string
 ) {
   console.log(" *** Updating mappings *** ");
   await deleteOldConfig(mappings);
@@ -41,7 +42,7 @@ export async function updateServerConfigs(
     }
     await fs.writeFileSync(
       path.join(config.serverConfigDir, filename),
-      await generateServerConfig(mapping)
+      await generateServerConfig(mapping, dappnodeDomain)
     );
   }
 }

--- a/src/nginx/templater.ts
+++ b/src/nginx/templater.ts
@@ -5,13 +5,14 @@ import { config } from "../config";
 import { DomainMapping } from "../types";
 
 export async function generateServerConfig(
-  mapping: DomainMapping
+  mapping: DomainMapping,
+  dappnodeDomain: string
 ): Promise<string> {
   const data = {
     certPath: config.certPath,
     keyPath: config.keyPath,
     dhparamPath: config.dhparamPath,
-    domain: `${mapping.from}.${process.env._DAPPNODE_GLOBAL_DOMAIN}`,
+    domain: `${mapping.from}.${dappnodeDomain}`,
     target: mapping.to,
     external: mapping.external,
   };


### PR DESCRIPTION
It looks like sometimes dappmanager is not able to inject the env `_DAPPNODE_GLOBAL_DOMAIN` into the HTTPS package, probably because the dappmanager is not properly running at the time HTTPS is started. In order to avoid this, if the env is empty, the package will try to retrieve this from the dappmanager API.