### PR TITLE
Allow CSR overwrite

### DIFF
--- a/src/certificates/openssl.ts
+++ b/src/certificates/openssl.ts
@@ -39,9 +39,11 @@ async function generateDomainKey() {
 
 async function createCSR(dappnodeDomain: string) {
   if (fs.existsSync(config.csrPath)) {
-    console.log("Exists, skipping");
-    return;
+    console.log("CSR exists. Overwriting it...");
+  } else {
+    console.log("CSR does not exist. Creating it...");
   }
+
   await shell(
     `openssl req -new -sha256 -key ${config.keyPath} -subj '/CN=${dappnodeDomain}' -addext 'subjectAltName = DNS:*.${dappnodeDomain}' > ${config.csrPath}`
   );


### PR DESCRIPTION
CSR can now be overwritten. It fixes the issue of a CSR being wrongly created that will be kept across the different restarts of the HTTPS package