### PR TITLE
Set minimum dappnode version to 0.2.95

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -20,7 +20,7 @@
       "url": "https://github.com/dappnode/DNP_HTTPS/issues"
     },
     "requirements": {
-      "minimumDappnodeVersion": "0.2.51"
+      "minimumDappnodeVersion": "0.2.95"
     },
     "backup": [
       {


### PR DESCRIPTION
Set minimum dappnode version to 0.2.95 to ensure auth compatibility
