### PR TITLE
Fix DH param generation 

### DIFF
--- a/src/certificates/openssl.ts
+++ b/src/certificates/openssl.ts
@@ -5,9 +5,9 @@ import fs from "fs";
 
 const keyLength = 2048;
 
-async function isDHParamValid() {
+async function isDHParamValid(dhparamPath: string) {
   try {
-    await shell(`openssl dhparam -check < ${path}`);
+    await shell(`openssl dhparam -check < ${dhparamPath}`);
     return true;
   } catch {
     return false;
@@ -22,7 +22,7 @@ async function certExpiringDate(pem: string) {
 }
 
 async function generateDHParam() {
-  if (fs.existsSync(config.dhparamPath) && isDHParamValid()) {
+  if (fs.existsSync(config.dhparamPath) && isDHParamValid(config.dhparamPath)) {
     console.log("Valid, skipping");
     return;
   }

--- a/src/certificates/openssl.ts
+++ b/src/certificates/openssl.ts
@@ -5,9 +5,9 @@ import fs from "fs";
 
 const keyLength = 2048;
 
-async function isDHParamValid(dhparamPath: string) {
+async function isDHParamValid() {
   try {
-    await shell(`openssl dhparam -check < ${dhparamPath}`);
+    await shell(`openssl dhparam -check < ${config.dhparamPath}`);
     return true;
   } catch {
     return false;
@@ -22,7 +22,7 @@ async function certExpiringDate(pem: string) {
 }
 
 async function generateDHParam() {
-  if (fs.existsSync(config.dhparamPath) && isDHParamValid(config.dhparamPath)) {
+  if (fs.existsSync(config.dhparamPath) && isDHParamValid()) {
     console.log("Valid, skipping");
     return;
   }


### PR DESCRIPTION
This PR aims to fix the following bug:

```
Failed to reconfigure NGINX ShellError: Command failed: nginx -s reload
nginx: [emerg] PEM_read_bio_DHparams("/etc/ssl/dappnode/wildcard_certs/dhparam.pem") failed (SSL: error:0909006C:PEM routines:get_name:no start line:Expecting: DH PARAMETERS)

    at shell (/usr/src/app/build/utils/shell.js:56:19)
    at async reconfigureNGINX (/usr/src/app/build/api/utils/nginx.js:15:13)
    at async /usr/src/app/build/api/app.js:35:30 {
  cmd: 'nginx -s reload',
  killed: false,
  code: 1,
  signal: null,
  stdout: '',
  stderr: 'nginx: [emerg] PEM_read_bio_DHparams("/etc/ssl/dappnode/wildcard_certs/dhparam.pem") failed (SSL: error:0909006C:PEM routines:get_name:no start line:Expecting: DH PARAMETERS)\n'
}
```

It was caused due to `/etc/ssl/dappnode/wildcard_certs/dhparam.pem` being empty