### PR TITLE
Use await to check DH params

### DIFF
--- a/src/certificates/openssl.ts
+++ b/src/certificates/openssl.ts
@@ -22,7 +22,7 @@ async function certExpiringDate(pem: string) {
 }
 
 async function generateDHParam() {
-  if (fs.existsSync(config.dhparamPath) && isDHParamValid()) {
+  if (fs.existsSync(config.dhparamPath) && await isDHParamValid()) {
     console.log("Valid, skipping");
     return;
   }


### PR DESCRIPTION
DH params validity would return `true` every time due to an async function being called without `await`