### PR TITLE
Remove hardcoded docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: "3.5"
 services:
   https.dnp.dappnode.eth:
     build: .
-    image: "https.dnp.dappnode.eth:0.2.0"
     container_name: DAppNodeCore-https.dnp.dappnode.eth
     restart: always
     ports:


### PR DESCRIPTION
Removed hardcoded docker image, causing the following issue due to being outdated (version to publish is 0.2.2, but image is set to version 0.2.0):

![image](https://github.com/dappnode/DNP_HTTPS/assets/144998261/7edd04d3-eaa7-45fb-b271-7436ec2d037e)

https://github.com/dappnode/DNP_HTTPS/actions/runs/9875324512/job/27315763513